### PR TITLE
Allow install on Raspian

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -57,6 +57,7 @@ DISTRIBUTION_TO_INSTALLER = {
     "Red Hat Enterprise Linux Server": YUM_INSTALL_COMMAND,
     "Amazon Linux AMI": YUM_INSTALL_COMMAND,
     "CentOS Linux": YUM_INSTALL_COMMAND,
+    "Raspbian GNU": APT_INSTALL_COMMAND,
 }
 
 


### PR DESCRIPTION
Previously:

```
Traceback (most recent call last):
  File "./setup.py", line 587, in <module>
    main()
  File "./setup.py", line 580, in main
    install_plugin()
  File "./setup.py", line 498, in install_plugin
    install_packages(SYSTEM_DEPENDENCIES)
  File "./setup.py", line 254, in install_packages
    command = DISTRIBUTION_TO_INSTALLER[detect_linux_distribution()] + " ".join(packages)
KeyError: 'Raspbian GNU'
```

I've installed it and it runs fine with no other changes.
