### PR TITLE
Fix typo on doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ LoadPlugin logfile
 
 <Plugin logfile>
        LogLevel info
-       File /var/log/collectd.log
+       File "/var/log/collectd.log"
        Timestamp true
        PrintSeverity false
 </Plugin>


### PR DESCRIPTION
This PR is just a trivial one. It seems `logfile` plugin's `File` directive must contain `""`. I tested collectd-5.4.1 on Amazon Linux hvm-2016.09.1.20161221-x86_64-gp2.

```bash
[ec2-user@ip-172-31-28-8 collectd.d]$ grep -F 'File /var/log/collectd.log' --line-number /etc/collectd.conf
66:       File /var/log/collectd.log
[ec2-user@ip-172-31-28-8 collectd.d]$ collectd -t -C /etc/collectd.conf
Parse error in file `/etc/collectd.conf', line 66 near `/': syntax error, unexpected SLASH
yyparse returned error #1
configfile: Cannot read file `/etc/collectd.conf'.
Unable to read config file /etc/collectd.conf.
Error: Reading the config file failed!
Read the syslog for details.
[ec2-user@ip-172-31-28-8 collectd.d]$ grep -F 'File "/var/log/collectd.log"' --line-number /etc/collectd.conf
66:       File "/var/log/collectd.log"
[ec2-user@ip-172-31-28-8 collectd.d]$ collectd -t -C /etc/collectd.conf
[ec2-user@ip-172-31-28-8 collectd.d]$ echo $?
0
```