### PR TITLE
Non-interactive setup

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -54,7 +54,8 @@ CLOUD_WATCH_COLLECTD_DETECTION_REGEX = re.compile('^Import [\'\"]cloudwatch_writ
 COLLECTD_CONFIG_INCLUDE_REGEX = re.compile("^Include [\'\"](.*?\.conf)[\'\"]", re.MULTILINE | re.IGNORECASE)
 COLLECTD_PYTHON_PLUGIN_CONFIGURATION_REGEX = re.compile("^LoadPlugin python$|^<LoadPlugin python>$", re.MULTILINE | re.IGNORECASE)
 
-logger = logging.getLogger(__name__)
+logging.basicConfig()
+logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 DISTRIBUTION_TO_INSTALLER = {

--- a/src/setup.py
+++ b/src/setup.py
@@ -343,7 +343,7 @@ class InteractiveConfigurator(object):
             self._configure_push_constant_non_interactive()
             self._configure_plugin_installation_method_non_interactive()
             self._configure_debug_non_interactive()
-            if self.debug_setup():
+            if self.debug_setup:
                 self._debug_setup()
         else:
             self._configure_region()
@@ -474,7 +474,6 @@ class InteractiveConfigurator(object):
         self.config.credentials_file_exist = path.exists(str(self.config.credentials_path))
         print "self.config.credentials_file_exist = ", self.config.credentials_file_exist
         if not self.config.credentials_file_exist:
-            print 'BEBUG: file not exist'
             self.config.access_key = self.access_key
             self.config.secret_key = self.secret_key
 
@@ -510,7 +509,6 @@ class InteractiveConfigurator(object):
                     creds_path = self.creds_path
             else:
                 creds_path = recommended_path
-        print 'DEBUG make dir = ', creds_path
         make_dirs(path.dirname(creds_path))
         return creds_path
 
@@ -765,7 +763,7 @@ def main():
     )
     parser.add_argument(
         '-D', '--debug_setup', default=False,
-        action='store_true', help='Provides verbose logging of metrics emitted to CloudWatch'
+        action='store_true', help='Provides verbose logging during setup process'
     )
     args = parser.parse_args()
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -672,11 +672,6 @@ def main():
         metavar='CREDENTIALS_PATH', default=None
     ),
     parser.add_argument(
-        '-b', '--creds_path', required=False,
-        help='Absolute path to AWS credentials file',
-        metavar='CREDENTIALS_PATH', default=None
-    ),
-    parser.add_argument(
         '-d', '--debug', default=False,
         action='store_true', help='Provides verbose logging of metrics emitted to CloudWatch'
     )

--- a/src/setup.py
+++ b/src/setup.py
@@ -341,7 +341,8 @@ class InteractiveConfigurator(object):
             self._configure_push_asg_non_interactive()
             self._configure_push_constant_non_interactive()
             self._configure_plugin_installation_method_non_interactive()
-            if self.debug: self._debug()
+            if self.debug:
+                self._debug()
         else:
             self._configure_region()
             self._configure_hostname()
@@ -688,7 +689,7 @@ def main():
         description='Script for custom installation process for collectd AWS CloudWatch plugin'
     )
     parser.add_argument(
-        '-i', '--non_interactive', required=False,
+        '-I', '--non_interactive', required=False,
         help='Non interactive mode',
         default=False, action='store_true'
     )
@@ -754,6 +755,17 @@ def main():
     )
 
     args = parser.parse_args()
+
+    if args.proxy_port is None and args.proxy_name or args.proxy_port and args.proxy_name is None:
+        parser.error('To enable proxy, use both --proxy_name and --proxy_port ')
+
+    if args.access_key is None and args.secret_key or args.access_key and args.secret_key is None:
+        parser.error('For IAM credentials, use both --secret_key and --access_key')
+
+    if args.push_constant is None and args.dimension_value:
+        parser.error('To include the FixedDimension as a metric dimension, '
+                     'use both --push_constant and dimension_value')
+
     non_interactive = args.non_interactive
     host = args.host_name
     region = args.region

--- a/src/setup.py
+++ b/src/setup.py
@@ -540,7 +540,6 @@ class InteractiveConfigurator(object):
         logger.info('PUSH ASG: {}'.format(self.config.push_asg))
         logger.info('PUSH CONSTANT: {}'.format(self.config.push_constant))
         logger.info('CONSTANT DIMENSION VALUE: {}'.format(self.config.constant_dimension_value))
-        logger.info('CREDENTIALS PATH: {}'.format(self.config.credentials_path))
         logger.info('SECRET KEY: {}'.format(self.config.secret_key))
         logger.info('ACCESS KEY: {}'.format(self.config.access_key))
         logger.info('HOST: {}'.format(self.config.host))
@@ -550,6 +549,7 @@ class InteractiveConfigurator(object):
         logger.info('METHOD ONLY ADD PLUGIN: {}'.format(self.config.only_add_plugin))
         logger.info('USE RECOMMENDED CONFIG: {}'.format(self.config.use_recommended_collectd_config))
         logger.info('REGION: {}'.format(self.config.region))
+        logger.info('IAM ROLE (metadata): {}'.format(self.metadata_reader.get_iam_role_name()))
 
 class Prompt(object):
     _DEFAULT_PROMPT = "Enter choice [" + Color.green("{}") + "]: "

--- a/src/setup.py
+++ b/src/setup.py
@@ -54,7 +54,7 @@ CLOUD_WATCH_COLLECTD_DETECTION_REGEX = re.compile('^Import [\'\"]cloudwatch_writ
 COLLECTD_CONFIG_INCLUDE_REGEX = re.compile("^Include [\'\"](.*?\.conf)[\'\"]", re.MULTILINE | re.IGNORECASE)
 COLLECTD_PYTHON_PLUGIN_CONFIGURATION_REGEX = re.compile("^LoadPlugin python$|^<LoadPlugin python>$", re.MULTILINE | re.IGNORECASE)
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 DISTRIBUTION_TO_INSTALLER = {

--- a/src/setup.py
+++ b/src/setup.py
@@ -399,6 +399,7 @@ class InteractiveConfigurator(object):
         except MetadataRequestException as e:
             print(Color.yellow("\nAWS region could not be automatically detected. Cause:" + str(e)))
             self.config.region = self._get_region()
+            logger.info('DEBUG')
             logger.info(self.config.region)
 
     def _get_region(self):

--- a/src/setup.py
+++ b/src/setup.py
@@ -666,68 +666,68 @@ def main():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         description='Script for custom installation process for collectd AWS CloudWatch plugin'
-    ),
+    )
     parser.add_argument(
         '-i', '--non_interactive', required=False,
         help='Non interactive mode',
         default=False, action='store_true'
-    ),
+    )
     parser.add_argument(
         '-H', '--host_name', required=False,
         help='Manual override for EC2 Instance ID and Host information propagated by collectd',
         metavar='HOST_NAME', default=None
-    ),
+    )
     parser.add_argument(
         '-r', '--region', required=False,
         help='Manual override for region used to publish metrics',
         metavar='REGION', default=None
-    ),
+    )
     parser.add_argument(
         '-n', '--proxy_name', required=False,
         help='Proxy server name',
         metavar='NAME', default=None
-    ),
+    )
     parser.add_argument(
         '-p', '--proxy_port', required=False,
         help='Proxy server port',
         metavar='PORT', default=None
-    ),
+    )
     parser.add_argument(
         '-a', '--access_key', required=False,
         help='AWS IAM user access key',
         metavar='ACCESS_KEY', default=None
-    ),
+    )
     parser.add_argument(
         '-s', '--secret_key', required=False,
         help='AWS IAM user secret key',
         metavar='SECRET_KEY', default=None
-    ),
+    )
     parser.add_argument(
         '-P', '--creds_path', required=False,
         help='Absolute path to AWS credentials file',
         metavar='CREDENTIALS_PATH', default=None
-    ),
+    )
     parser.add_argument(
         '-m', '--installation_method', required=False,
         help='Choose how to install CloudWatch plugin in collectd',
         choices=['recommended', 'add', 'not_modify'],
         metavar='recommended|add|not_modify', default=None
-    ),
+    )
     parser.add_argument(
         '-g', '--push_asg', required=False,
         help='Include the Auto-Scaling Group name as a metric dimension:',
         default=None, action='store_true'
-    ),
+    )
     parser.add_argument(
         '-c', '--push_constant', required=False,
         help='Include the FixedDimension as a metric dimension',
         default=None, action='store_true'
-    ),
+    )
     parser.add_argument(
         '-v', '--dimension_value', required=False,
         help='FixedDimension value',
         metavar='DIMENSION_VALUE', default=None
-    ),
+    )
     parser.add_argument(
         '-d', '--debug', default=False,
         action='store_true', help='Provides verbose logging of metrics emitted to CloudWatch'

--- a/src/setup.py
+++ b/src/setup.py
@@ -522,12 +522,15 @@ class InteractiveConfigurator(object):
 
     def _configure_plugin_installation_method_non_interactive(self):
         # recommended|add|not_modify
-        if self.installation_method == 'not_modify':
+        if not self.installation_method:
             pass
-        if self.installation_method == 'add':
-            self.config.only_add_plugin = True
-        if self.installation_method == 'recommended':
-            self.config.use_recommended_collectd_config = True
+        else:
+            if self.installation_method == 'not_modify':
+                pass
+            if self.installation_method == 'add':
+                self.config.only_add_plugin = True
+            if self.installation_method == 'recommended':
+                self.config.use_recommended_collectd_config = True
 
 
 class Prompt(object):

--- a/src/setup.py
+++ b/src/setup.py
@@ -764,7 +764,10 @@ def main():
 
     if args.push_constant is None and args.dimension_value:
         parser.error('To include the FixedDimension as a metric dimension, '
-                     'use both --push_constant and dimension_value')
+                     'use both --push_constant and --dimension_value')
+
+    if args.creds_path and args.secret_key is None and args.access_key is None:
+        parser.error('Credential path (--creds_path) used only with --secret_key and --access_key arguments')
 
     non_interactive = args.non_interactive
     host = args.host_name

--- a/src/setup.py
+++ b/src/setup.py
@@ -313,7 +313,7 @@ class InteractiveConfigurator(object):
 
     def __init__(self, plugin_config, metadata_reader, collectd_info, non_interactive, region, host,
                  proxy_name, proxy_port, access_key, secret_key, creds_path, installation_method,push_asg,
-                 push_constant, dimension_value):
+                 push_constant, dimension_value, debug):
         self.config = plugin_config
         self.metadata_reader = metadata_reader
         self.collectd_info = collectd_info
@@ -329,6 +329,7 @@ class InteractiveConfigurator(object):
         self.push_asg = push_asg
         self.push_constant = push_constant
         self.dimension_value = dimension_value
+        self.debug = debug
 
     def run(self):
         if self.non_interactive:
@@ -340,7 +341,7 @@ class InteractiveConfigurator(object):
             self._configure_push_asg_non_interactive()
             self._configure_push_constant_non_interactive()
             self._configure_plugin_installation_method_non_interactive()
-            self.debug()
+            if self.debug: self._debug()
         else:
             self._configure_region()
             self._configure_hostname()
@@ -533,9 +534,21 @@ class InteractiveConfigurator(object):
             if self.installation_method == 'recommended':
                 self.config.use_recommended_collectd_config = True
 
-    def debug(self):
-        logger.info('DEBUG')
-        logger.info(self.config.region)
+    def _debug(self):
+        logger.info('-=**********DEBUG**********=-')
+        logger.info('PUSH ASG: {}'.format(self.config.push_asg))
+        logger.info('PUSH CONSTANT: {}'.format(self.config.push_constant))
+        logger.info('CONSTANT DIMENSION VALUE: {}'.format(self.config.constant_dimension_value))
+        logger.info('CREDENTIALS PATH: {}'.format(self.config.credentials_path))
+        logger.info('SECRET KEY: {}'.format(self.config.secret_key))
+        logger.info('ACCESS KEY: {}'.format(self.config.access_key))
+        logger.info('HOST: {}'.format(self.config.host))
+        logger.info('PROXY NAME: {}'.format(self.config.proxy_server_name))
+        logger.info('PROXY PORT: {}'.format(self.config.proxy_server_port))
+        logger.info('CREDENTIALS PATH: {}'.format(self.config.credentials_path))
+        logger.info('METHOD ONLY ADD PLUGIN: {}'.format(self.config.only_add_plugin))
+        logger.info('USE RECOMMENDED CONFIG: {}'.format(self.config.use_recommended_collectd_config))
+        logger.info('REGION: {}'.format(self.config.region))
 
 class Prompt(object):
     _DEFAULT_PROMPT = "Enter choice [" + Color.green("{}") + "]: "
@@ -796,7 +809,7 @@ def main():
         metadata_reader = MetadataReader()
         InteractiveConfigurator(plugin_config, metadata_reader, COLLECTD_INFO, non_interactive, region, host,
                                 proxy_name, proxy_port, access_key, secret_key, creds_path,installation_method, push_asg,
-                                push_constant, dimension_value).run()
+                                push_constant, dimension_value, debug).run()
         PluginConfigWriter(plugin_config).write()
 
     def _inject_plugin_configuration():

--- a/src/setup.py
+++ b/src/setup.py
@@ -340,6 +340,7 @@ class InteractiveConfigurator(object):
             self._configure_push_asg_non_interactive()
             self._configure_push_constant_non_interactive()
             self._configure_plugin_installation_method_non_interactive()
+            self.debug()
         else:
             self._configure_region()
             self._configure_hostname()
@@ -400,8 +401,6 @@ class InteractiveConfigurator(object):
         except MetadataRequestException as e:
             print(Color.yellow("\nAWS region could not be automatically detected. Cause:" + str(e)))
             self.config.region = self._get_region()
-            logger.info('DEBUG')
-            logger.info(self.config.region)
 
     def _get_region(self):
         return Prompt("Enter one of the available regions from: " +
@@ -534,6 +533,9 @@ class InteractiveConfigurator(object):
             if self.installation_method == 'recommended':
                 self.config.use_recommended_collectd_config = True
 
+    def debug(self):
+        logger.info('DEBUG')
+        logger.info(self.config.region)
 
 class Prompt(object):
     _DEFAULT_PROMPT = "Enter choice [" + Color.green("{}") + "]: "

--- a/src/setup.py
+++ b/src/setup.py
@@ -672,7 +672,7 @@ def main():
         metavar='CREDENTIALS_PATH', default=None
     ),
     parser.add_argument(
-        '-b', '--', required=False,
+        '-b', '--creds_path', required=False,
         help='Absolute path to AWS credentials file',
         metavar='CREDENTIALS_PATH', default=None
     ),

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -1,5 +1,7 @@
 import unittest
+import tempfile
 from subprocess import CalledProcessError
+from os import path, remove, rmdir
 
 from mock import patch, Mock
 
@@ -124,3 +126,67 @@ class ColorTest(unittest.TestCase):
         self.assertEquals(installer.Color.GREEN + test_string + self.END, installer.Color.green(test_string))
         self.assertEquals(installer.Color.YELLOW + test_string + self.END, installer.Color.yellow(test_string))
         self.assertEquals(installer.Color.CYAN + test_string + self.END, installer.Color.cyan(test_string))
+
+class NonInteractiveTests(unittest.TestCase):
+    plugin_config = installer.PluginConfig
+    metadata_reader = None
+    collectd_info = None
+    non_interactive = True
+    region = 'test_region'
+    host = 'test_host'
+    proxy_name = 'test_proxy'
+    proxy_port = 'test_proxy_port'
+    access_key = 'test_access_key'
+    secret_key = 'test_secret_key'
+    installation_method = 'recommended'
+    push_asg = False
+    push_constant = True
+    dimension_value = 'test_all'
+    debug_setup = True
+    debug = True
+
+    tmp = tempfile.mkdtemp(prefix='/tmp/')
+    creds_path = tmp + '/' + 'test_creds_file'
+
+
+    def test_params(self):
+        non_interactive_installer = installer.InteractiveConfigurator(self.plugin_config, self.metadata_reader,
+                                                                      self.collectd_info,
+                                                                      self.non_interactive, self.region,
+                                                                      self.host, self.proxy_name, self.proxy_port,
+                                                                      self.access_key, self.secret_key,
+                                                                      self.creds_path, self.installation_method,
+                                                                      self.push_asg, self.push_constant,
+                                                                      self.dimension_value, self.debug_setup, self.debug)
+
+        non_interactive_installer._configure_region_non_interactive()
+        self.assertEquals(self.plugin_config.region, self.region)
+
+        non_interactive_installer._configure_hostname_non_interactive()
+        self.assertEquals(self.plugin_config.host, self.host)
+
+        non_interactive_installer._configure_proxy_server_name_non_interactive()
+        self.assertEquals(self.plugin_config.proxy_server_name, self.proxy_name)
+
+        non_interactive_installer._configure_proxy_server_port_non_interactive()
+        self.assertEquals(self.plugin_config.proxy_server_port, self.proxy_port)
+
+        non_interactive_installer._configure_credentials_non_interactive()
+        self.assertEquals(self.plugin_config.access_key, self.access_key)
+        self.assertEquals(self.plugin_config.secret_key, self.secret_key)
+        config_writer = installer.PluginConfigWriter(self.plugin_config)
+        config_writer._write_credentials_file()
+        self.assertEquals(path.exists(self.plugin_config.credentials_path), True)
+        remove(self.creds_path)
+        rmdir(self.tmp)
+
+        non_interactive_installer._configure_push_asg_non_interactive()
+        self.assertEquals(self.plugin_config.push_asg, self.push_asg)
+
+        non_interactive_installer._configure_push_constant_non_interactive()
+        self.assertEquals(self.plugin_config.push_constant, self.push_constant)
+        self.assertEquals(self.plugin_config.constant_dimension_value, self.dimension_value)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -186,7 +186,3 @@ class NonInteractiveTests(unittest.TestCase):
         non_interactive_installer._configure_push_constant_non_interactive()
         self.assertEquals(self.plugin_config.push_constant, self.push_constant)
         self.assertEquals(self.plugin_config.constant_dimension_value, self.dimension_value)
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
First, I want to say thank you guys, for that cool and very useful plugin. But for my needs (I suppose not only for my) I need non-interactive setup, cause that plugin is a part of debian package. So let me introduse setup, with non-interactive feature. So the work is not fully done. The purpose of the PR is to show way how I see it to be done, and to confirm that not only I intrested in such feature. Thank you for your attension.

Examples:

1.) sudo ./setup.py -i
inteactive mode, with EC2 metadata as defaults if possible (region, hostname, IAM)
2.) sudo ./setup.py -i -r <region_name> -H <hostname> 
intercactive mode, with overrading region and hostname
3.) sudo ./setup.py -i -a <access key> -s <secret_key>
interactive mode, with IAM user
4.) sudo ./setup  -i -a <access key> -s <secret_key> -P <creds_path>
interactive mode, with IAM user and custom aws credentials path
