### PR TITLE
Update setup.py to include Debian distro

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -61,6 +61,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 DISTRIBUTION_TO_INSTALLER = {
+    "Debian GNU": APT_INSTALL_COMMAND,
     "Ubuntu": APT_INSTALL_COMMAND,
     "Red Hat Enterprise Linux Server": YUM_INSTALL_COMMAND,
     "Amazon Linux AMI": YUM_INSTALL_COMMAND,


### PR DESCRIPTION
Hi,

I've noticed the installer fails on Debian 9.
This is a simple fix.

Thanks!