### PR TITLE
change regex search string for linux distros

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -63,7 +63,7 @@ logger.setLevel(logging.DEBUG)
 DISTRIBUTION_TO_INSTALLER = {
     "Ubuntu": APT_INSTALL_COMMAND,
     "Red Hat Enterprise Linux Server": YUM_INSTALL_COMMAND,
-    "Amazon Linux AMI": YUM_INSTALL_COMMAND,
+    "Amazon Linux": YUM_INSTALL_COMMAND,
     "CentOS Linux": YUM_INSTALL_COMMAND,
 }
 


### PR DESCRIPTION
To detect the Linux distribution type, setup.py checks /etc/*-release
files which matches two files on Amazon Linux (new and old versions):

    - /etc/os-release
    - /etc/system-release

On Amazon Linux 2, "system-release" contains the single line
    - Amazon Linux 2
While on Amazon Linux < v2 "system-release" returns
    - Amazon Linux AMI release 2018.03

On Amazon Linux 2, "os-release" looks like the following:

```
NAME="Amazon Linux"
VERSION="2"
ID="amzn"
ID_LIKE="centos rhel fedora"
VERSION_ID="2"
PRETTY_NAME="Amazon Linux 2"
ANSI_COLOR="0;33"
CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2"
HOME_URL="https://amazonlinux.com/"
``
On Amazon Linux < v2, "os-release" looks like:

```
NAME="Amazon Linux AMI"
VERSION="2018.03"
ID="amzn"
ID_LIKE="rhel fedora"
VERSION_ID="2018.03"
PRETTY_NAME="Amazon Linux AMI 2018.03"
ANSI_COLOR="0;33"
CPE_NAME="cpe:/o:amazon:linux:2018.03:ga"
HOME_URL="http://aws.amazon.com/amazon-linux-ami/"
```

In `setup.py` the regex current matches the string
    - "Amazon Linux AMI"
But it this is shortened to just
    - "Amazon Linux"

both old and new versions of Amazon Linux will be matched by
the regex allowing the collectd-cloudwatch plugin to be
installed.