### PR TITLE
distinguish each value_list.host and pass through to cloudwatch dimension

### DIFF
--- a/src/cloudwatch/config/plugin.conf
+++ b/src/cloudwatch/config/plugin.conf
@@ -8,6 +8,8 @@
 # The host parameter can be used to override instance-id or host information published with every metric
 #host = "Server1"
 
+#pass_vl_host = "False"
+
 # The pass through option allows unsafe regexes such as '.*' or '.+'.
 # WARNING: ENABLING THIS OPTION MAY LEAD TO PUBLISHING A LARGE NUMBER OF METRICS
 #   SEE https://aws.amazon.com/cloudwatch/pricing/ TO UNDERSTAND HOW TO ESTIMATE YOUR BILL.

--- a/src/cloudwatch/modules/configuration/confighelper.py
+++ b/src/cloudwatch/modules/configuration/confighelper.py
@@ -39,6 +39,7 @@ class ConfigHelper(object):
         self.endpoint = ''
         self.ec2_endpoint = ''
         self.host = ''
+        self.pass_vl_host = False
         self.asg_name = 'NONE'
         self.proxy_server_name = ''
         self.proxy_server_port = ''
@@ -89,6 +90,7 @@ class ConfigHelper(object):
         self.push_asg = self.config_reader.push_asg
         self.push_constant = self.config_reader.push_constant
         self.constant_dimension_value = self.config_reader.constant_dimension_value
+        self.pass_vl_host = self.config_reader.pass_vl_host
         self._check_configuration_integrity()
     
     def _get_credentials_path(self):

--- a/src/cloudwatch/modules/configuration/configreader.py
+++ b/src/cloudwatch/modules/configuration/configreader.py
@@ -14,6 +14,7 @@ class ConfigReader(object):
     credentials_path -- the path to the file with AWS access and secret keys
     region -- the region in which host operates
     host -- the host name or instance name injected to each metric as dimension
+    pass_vl_host -- use host in value_list in dimension
     debug -- the mode in which plugin performs verbose logging of its operations
     pass_through -- the mode in which whitelist allows use of .* on its own
     
@@ -24,11 +25,13 @@ class ConfigReader(object):
     _LOGGER = get_logger(__name__)
     _DEBUG_DEFAULT_VALUE = False
     _ENABLE_HIGH_DEFINITION_METRICS_DEFAULT_VALUE = False
+    _PASS_VL_HOST_DEFAULT_VALUE = False
     _PASS_THROUGH_DEFAULT_VALUE = False
     _PUSH_ASG_DEFAULT_VALUE = False
     _PUSH_CONSTANT_DEFAULT_VALUE = False
     REGION_CONFIG_KEY = "region"
     HOST_CONFIG_KEY = "host"
+    PASS_VL_HOST_CONFIG_KEY = "pass_vl_host"
     CREDENTIALS_PATH_KEY = "credentials_path"
     DEBUG_CONFIG_KEY = "debug"
     PASS_THROUGH_CONFIG_KEY = "whitelist_pass_through"
@@ -45,6 +48,7 @@ class ConfigReader(object):
         self.credentials_path = ""
         self.region = ''
         self.host = ''
+        self.pass_vl_host = self._PASS_VL_HOST_DEFAULT_VALUE
         self.pass_through = self._PASS_THROUGH_DEFAULT_VALUE
         self.debug = self._DEBUG_DEFAULT_VALUE
         self.push_asg = self._PUSH_ASG_DEFAULT_VALUE
@@ -68,6 +72,7 @@ class ConfigReader(object):
         """
         self.credentials_path = self.reader_utils.get_string(self.CREDENTIALS_PATH_KEY)
         self.host = self.reader_utils.get_string(self.HOST_CONFIG_KEY)
+        self.pass_vl_host = self.reader_utils.try_get_boolean(self.PASS_VL_HOST_CONFIG_KEY, self._PASS_VL_HOST_DEFAULT_VALUE)
         self.region = self.reader_utils.get_string(self.REGION_CONFIG_KEY)
         self.proxy_server_name = self.reader_utils.get_string(self.PROXY_SERVER_NAME_KEY)
         self.proxy_server_port = self.reader_utils.get_string(self.PROXY_SERVER_PORT_KEY)

--- a/src/cloudwatch/modules/flusher.py
+++ b/src/cloudwatch/modules/flusher.py
@@ -128,6 +128,8 @@ class Flusher(object):
         key = dimension_key
         if self.enable_high_resolution_metrics:
             key = dimension_key + "-" + str(adjusted_time)
+        if self.config.pass_vl_host:
+            key = value_list.host + '/' + key
         if key in self.metric_map:
             nan_value_count = self._add_values_to_metrics(self.metric_map[key], value_list)
         else:

--- a/src/cloudwatch/modules/metricdata.py
+++ b/src/cloudwatch/modules/metricdata.py
@@ -139,6 +139,8 @@ class MetricDataBuilder(object):
         return "NONE"
 
     def _get_host_dimension(self):
+        if self.config.pass_vl_host:
+            return self.vl.host
         if self.config.host:
             return self.config.host
         return self.vl.host


### PR DESCRIPTION
Add a pass_vl_host flag to control whether to distinguish each value_list.host.
Then pass through this value to the CloudWatch dimension.
