### PR TITLE
add support for Amazon Linux 2

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -64,6 +64,7 @@ DISTRIBUTION_TO_INSTALLER = {
     "Ubuntu": APT_INSTALL_COMMAND,
     "Red Hat Enterprise Linux Server": YUM_INSTALL_COMMAND,
     "Amazon Linux AMI": YUM_INSTALL_COMMAND,
+    "Amazon Linux": YUM_INSTALL_COMMAND,
     "CentOS Linux": YUM_INSTALL_COMMAND,
 }
 


### PR DESCRIPTION
there is no mapping for Amazon Linux 2 so far.

I checked the name against the latest Amazon Linux 2 AMI `ami-a9d09ed1` in `us-west-2`