### PR TITLE
Add Amazon linux distribution to the list of distributions

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -64,6 +64,7 @@ DISTRIBUTION_TO_INSTALLER = {
     "Ubuntu": APT_INSTALL_COMMAND,
     "Red Hat Enterprise Linux Server": YUM_INSTALL_COMMAND,
     "Amazon Linux AMI": YUM_INSTALL_COMMAND,
+    "Amazon Linux": YUM_INSTALL_COMMAND,
     "CentOS Linux": YUM_INSTALL_COMMAND,
 }
 


### PR DESCRIPTION
*Issue #, if available: I have images with Amazon Linux as the distribution name which is not supported.

*Description of changes:*
Add Amazon Linux entry to the distributions map, which maps to yam.
I've tested that already. For more info email me: lantzman at amazon.com


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
