### PR TITLE
Fixed typo in autoscaling group name warning

### DIFF
--- a/src/cloudwatch/modules/client/ec2getclient.py
+++ b/src/cloudwatch/modules/client/ec2getclient.py
@@ -54,7 +54,7 @@ class EC2GetClient(object):
             ns={'ec2': 'http://ec2.amazonaws.com/doc/2016-11-15/'}
             return xmldoc.findall('ec2:tagSet/ec2:item[0]/ec2:value',ns)[0].text
         except Exception as e:
-            self._LOGGER.warning("Could not get the autoscalig group name using the following endpoint: '" + self.endpoint +"'. [Exception: " + str(e) + "]")
+            self._LOGGER.warning("Could not get the autoscaling group name using the following endpoint: '" + self.endpoint +"'. [Exception: " + str(e) + "]")
             self._LOGGER.warning("Request details: '" + request + "'")
             return "NONE"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixed a typo of 'autoscaling' in a warning related to not finding autoscaling group name at specified endpoint

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
