### PR TITLE
Implement offline install parameter for setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ sudo ./setup.py
 ```
 
  * Follow on screen instructions
+ 
+If you require offline installation, you can skip the depencency installation and provide local plugin src directory with --offline_install="/tmp/collectd_cloudwatch"
 
 ## Configuration
 


### PR DESCRIPTION
Fixes #83

Updated setup.py to accept an --offline_install parameter. You can then provide a path to the plugin source so no internet connectivity is required to run the setup. Also updated readme to reflect this.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
