### PR TITLE
Detect region correctly in Local Zones

### DIFF
--- a/src/cloudwatch/modules/configuration/metadatareader.py
+++ b/src/cloudwatch/modules/configuration/metadatareader.py
@@ -13,7 +13,7 @@ class MetadataReader(object):
     metadata_server -- the address of the local metadata server (Required)
     """
     _LOGGER = get_logger(__name__)
-    _REGION_METADATA_REQUEST = "latest/meta-data/placement/availability-zone/"
+    _IDENTITY_DOCUMENT_REQUEST = "latest/dynamic/instance-identity/document"
     _INSTANCE_ID_METADATA_REQUEST = "latest/meta-data/instance-id/"
     _IAM_ROLE_CREDENTIAL_REQUEST = "latest/meta-data/iam/security-credentials/"
     _TOTAL_RETRIES = 3
@@ -27,9 +27,9 @@ class MetadataReader(object):
         self.session.mount("http://", HTTPAdapter(max_retries=self._TOTAL_RETRIES))
         
     def get_region(self):
-        """ Get the region value from the metadata service, if the last character of region is A it is automatically trimmed """
-        region = self._get_metadata(MetadataReader._REGION_METADATA_REQUEST)
-        return region[:-1]
+        """ Get the region value from the metadata service """
+        document = self._get_metadata(MetadataReader._IDENTITY_DOCUMENT_REQUEST)
+        return loads(document)['region']
 
     def get_instance_id(self):
         """ Get the instance id value from the metadata service """

--- a/src/setup.py
+++ b/src/setup.py
@@ -195,7 +195,7 @@ class MetadataReader(object):
     The metadata reader class is responsible for retrieving configuration values from the local metadata server.
     """
     _METADATA_SERVICE_ADDRESS = 'http://169.254.169.254/'
-    _REGION_METADATA_REQUEST = "latest/meta-data/placement/availability-zone/"
+    _IDENTITY_DOCUMENT_REQUEST = "latest/dynamic/instance-identity/document"
     _INSTANCE_ID_METADATA_REQUEST = "latest/meta-data/instance-id/"
     _IAM_ROLE_CREDENTIAL_REQUEST = "latest/meta-data/iam/security-credentials/"
     _MAX_RETRIES = 1
@@ -207,9 +207,9 @@ class MetadataReader(object):
         self.metadata_server = self._METADATA_SERVICE_ADDRESS
 
     def get_region(self):
-        """ Get the region value from the metadata service, if the last character of region is A it is automatically trimmed """
-        region = self._get_metadata(MetadataReader._REGION_METADATA_REQUEST)
-        return region[:-1]
+        """ Get the region value from the metadata service """
+        document = self._get_metadata(MetadataReader._IDENTITY_DOCUMENT_REQUEST)
+        return loads(document)['region']
 
     def get_instance_id(self):
         """ Get the instance id value from the metadata service """
@@ -382,7 +382,7 @@ class InteractiveConfigurator(object):
         choice = Prompt("\nInclude the Auto-Scaling Group name as a metric dimension:", options=["No", "Yes"], default="1").run()
         if choice == "2":
             self.config.push_asg = True
-            
+
     def _get_constant_dimension_value(self):
         return Prompt(message="Enter FixedDimension value [" + Color.green("ALL") + "]: ", default="ALL").run()
 

--- a/test/test_confighelper.py
+++ b/test/test_confighelper.py
@@ -6,7 +6,7 @@ import cloudwatch.modules.collectd as collectd
 from cloudwatch.modules.configuration.confighelper import ConfigHelper
 from cloudwatch.modules.configuration.metadatareader import MetadataReader
 from helpers.fake_http_server import FakeServer
-
+from helpers.fake_metadata import FAKE_REGION, FAKE_IDENTITY_DOCUMENT_STRING
 
 class ConfigHelperTest(unittest.TestCase):
     CONFIG_DIR = "./test/config_files/"
@@ -51,12 +51,12 @@ class ConfigHelperTest(unittest.TestCase):
         ConfigHelper._DEFAULT_CREDENTIALS_PATH = self.VALID_CREDENTIALS_FILE
     
     def test_get_credentials_from_config_and_region_from_metadata(self):
-        self.server.set_expected_response("eu-west-1a", 200)
+        self.server.set_expected_response(FAKE_IDENTITY_DOCUMENT_STRING, 200)
         self.config_helper = ConfigHelper(config_path=ConfigHelperTest.VALID_CONFIG_WITH_CREDS_ONLY,metadata_server=self.server.get_url())
         assert_credentials(self.config_helper._credentials)
         self.assertEquals(None, self.config_helper.credentials.token)
         self.assertFalse(self.config_helper._use_iam_role_credentials)
-        self.assertEquals("eu-west-1", self.config_helper.region)
+        self.assertEquals(FAKE_REGION, self.config_helper.region)
     
     def test_timeout_on_getting_region_from_metadata(self):
         self.server.set_timeout_delay(MetadataReader._RESPONSE_TIMEOUT_IN_SECONDS * (MetadataReader._TOTAL_RETRIES + 1))
@@ -144,7 +144,7 @@ class ConfigHelperTest(unittest.TestCase):
         self.assertEquals("https://monitoring.eu-west-1.amazonaws.com/", self.config_helper.endpoint)
     
     def test_set_endpoint_from_metadata_server(self):
-        self.server.set_expected_response("eu-west-1a", 200)
+        self.server.set_expected_response(FAKE_IDENTITY_DOCUMENT_STRING, 200)
         self.config_helper = ConfigHelper(config_path=ConfigHelperTest.VALID_CONFIG_WITH_CREDS_ONLY, metadata_server=self.server.get_url())
         self.assertEquals("https://monitoring.eu-west-1.amazonaws.com/", self.config_helper.endpoint)
     
@@ -156,7 +156,7 @@ class ConfigHelperTest(unittest.TestCase):
     def test_instance_id_is_used_as_hostname_if_not_specified_in_config(self):
         expected_host = "Valid_Instance_ID"
         self.server.set_expected_response(expected_host, 200)
-        self.config_helper = ConfigHelper(config_path=ConfigHelperTest.VALID_CONFIG_WITH_CREDS_ONLY, metadata_server=self.server.get_url())
+        self.config_helper = ConfigHelper(config_path=ConfigHelperTest.VALID_CONFIG_WITH_CREDS_AND_REGION, metadata_server=self.server.get_url())
         self.assertEquals(expected_host, self.config_helper.host)
     
     def test_exception_is_handled_when_instance_id_cannot_be_retrieved(self):

--- a/test/test_metadatareader.py
+++ b/test/test_metadatareader.py
@@ -1,11 +1,11 @@
 import unittest
 import requests
 from helpers.fake_http_server import FakeServer
+from helpers.fake_metadata import FAKE_REGION, FAKE_IDENTITY_DOCUMENT_STRING
 from cloudwatch.modules.configuration.metadatareader import MetadataReader, MetadataRequestException
 
 class MetadataReaderTest(unittest.TestCase):
     FAKE_SERVER = None
-    REAL_REGION_STRING = "eu-west-1a"
     MINIMUM_NUMBER_OF_RETRIES = 3
     MAXIMUM_NUMBER_OF_RETRIES = 5
     
@@ -17,7 +17,7 @@ class MetadataReaderTest(unittest.TestCase):
         
     def setUp(self):
         self.server = MetadataReaderTest.FAKE_SERVER
-        self.server.set_expected_response(MetadataReaderTest.REAL_REGION_STRING, 200)
+        self.server.set_expected_response(FAKE_IDENTITY_DOCUMENT_STRING, 200)
         self.metadata_reader = MetadataReader(self.server.get_url())
     
     def test_number_of_retries_is_within_expected_range(self):
@@ -26,10 +26,8 @@ class MetadataReaderTest(unittest.TestCase):
             self.fail("The total number of retries for metadata reader is invalid")
     
     def test_get_region_from_metadata(self):
-        self.server.set_expected_response(MetadataReaderTest.REAL_REGION_STRING, 200)
-        self.assertEquals(MetadataReaderTest.REAL_REGION_STRING[:-1], self.metadata_reader.get_region()) #trimmed last character 'a'
-        self.server.set_expected_response("us-east-2c", 200)
-        self.assertEquals("us-east-2", self.metadata_reader.get_region())
+        self.server.set_expected_response(FAKE_IDENTITY_DOCUMENT_STRING, 200)
+        self.assertEquals(FAKE_REGION, self.metadata_reader.get_region())
     
     def test_get_full_configuration_from_config_file(self):
         self.server.set_expected_response("invalid request", 404)


### PR DESCRIPTION
The previous logic assumed that the region could always be determined
by stripping the last character from the Availability Zone. This is no
longer true; for example the Local Zone us-west-2-lax-1a corresponds
to the region us-west-2.

Read the region directly from the instance identity document instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
