### PR TITLE
added an option to suppress restarting

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -834,6 +834,10 @@ def main():
         '-D', '--debug_setup', default=False,
         action='store_true', help='Provides verbose logging during setup process'
     )
+    parser.add_argument(
+        '-w', '--without_restarting', default=False,
+        action='store_true', help='Excludes collectd restarting from setup process'
+    )
     args = parser.parse_args()
 
     if args.proxy_port is None and args.proxy_name or args.proxy_port and args.proxy_name is None:
@@ -865,6 +869,7 @@ def main():
     dimension_value = args.dimension_value
     debug_setup = args.debug_setup
     debug = args.debug
+    without_restarting = args.without_restarting
 
     def install_plugin():
         try:
@@ -876,7 +881,8 @@ def main():
             _run_command(UNTAR_PLUGIN_CMD, exit_on_failure=True)
             _run_command(COPY_PLUGIN_CMD, shell=True, exit_on_failure=True)
             supply_config()
-            restart_collectd()
+            if not without_restarting:
+                restart_collectd()
         finally:
             remove_temp_dir()
 


### PR DESCRIPTION
added an option for setup.py:

* `-w`, `--without_restarting`: excludes collectd restarting from setup process

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
